### PR TITLE
Dynamic token refresh margin

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageId>$(AssemblyName)</PackageId>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <Version>1.1.1</Version>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageId>$(AssemblyName)</PackageId>

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## 1.1.1
-- Dynamic token refresh margin ([#2 by philon-msft](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/pull/1))
+- Dynamic token refresh margin ([#3 by philon-msft](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/pull/3))
 
 ## 1.1.0
 - AAD Support ([#1 by philon-msft](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/pull/1))

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,5 +2,8 @@
 
 ## Unreleased
 
+## 1.1.1
+- Dynamic token refresh margin ([#2 by philon-msft](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/pull/1))
+
 ## 1.1.0
 - AAD Support ([#1 by philon-msft](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/pull/1))

--- a/sample/Sample.cs
+++ b/sample/Sample.cs
@@ -102,7 +102,7 @@ finally
 }
 
 // This loop will execute commands on the Redis cache every five seconds indefinitely. 
-// Let it run for more than 24 hours to see how the connection remains functional even after the initial token has expired. 
+// Let it run for longer than a token lifespan (e.g. 24 hours) to see how the connection remains functional even after the initial token has expired. 
 var database = connectionMultiplexer?.GetDatabase();
 while (true)
 {

--- a/src/AzureCacheOptions.cs
+++ b/src/AzureCacheOptions.cs
@@ -45,7 +45,7 @@ public class AzureCacheOptions
         var lifespan = expiry - acquired;
         var age = DateTime.UtcNow - acquired;
 
-        return (age.Ticks / lifespan.Ticks) > .75; // Refresh if current token has exceeded 75% of its lifespan
+        return ((double)age.Ticks / lifespan.Ticks) > .75; // Refresh if current token has exceeded 75% of its lifespan
     };
 
     /// <summary>

--- a/src/AzureCacheOptions.cs
+++ b/src/AzureCacheOptions.cs
@@ -38,10 +38,15 @@ public class AzureCacheOptions
     public bool ThrowOnTokenRefreshFailure = true;
 
     /// <summary>
-    /// How long before expiration should a token be refreshed. 
-    /// Tokens have a 24hr lifespan by default, and the default margin of 4 hours allows time for recovery of any issues preventing refresh before the token expires.
+    /// Determines whether the current token should be refreshed, based on its age and lifespan
     /// </summary>
-    internal TimeSpan TokenExpirationMargin = TimeSpan.FromHours(4);
+    public Func<DateTime, DateTime, bool> ShouldTokenBeRefreshed = (DateTime acquired, DateTime expiry) =>
+    {
+        var lifespan = expiry - acquired;
+        var age = DateTime.UtcNow - acquired;
+
+        return (age.Ticks / lifespan.Ticks) > .75; // Refresh if current token has exceeded 75% of its lifespan
+    };
 
     /// <summary>
     /// Periodic interval to check token for expiration, acquire new tokens, and re-authenticate connections.

--- a/src/Microsoft.Azure.StackExchangeRedis.csproj
+++ b/src/Microsoft.Azure.StackExchangeRedis.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Version>1.1.1</Version>
     <Authors>Microsoft</Authors>
     <Description>Extension package for StackExchange.Redis to be used with the Azure Cache for Redis service</Description>
     <AssemblyName>Microsoft.Azure.StackExchangeRedis</AssemblyName>

--- a/src/Microsoft.Azure.StackExchangeRedis.csproj
+++ b/src/Microsoft.Azure.StackExchangeRedis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>Microsoft</Authors>
     <Description>Extension package for StackExchange.Redis to be used with the Azure Cache for Redis service</Description>
     <AssemblyName>Microsoft.Azure.StackExchangeRedis</AssemblyName>

--- a/src/PublicAPI.Shipped.txt
+++ b/src/PublicAPI.Shipped.txt
@@ -14,6 +14,7 @@ Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.ClientId -> string?
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.PrincipalId -> string?
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.ServicePrincipalSecret -> string?
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.ServicePrincipalTenantId -> string?
+Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.ShouldTokenBeRefreshed -> System.Func<System.DateTime, System.DateTime, bool>!
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.ThrowOnTokenRefreshFailure -> bool
 Microsoft.Azure.StackExchangeRedis.IAzureCacheTokenEvents
 Microsoft.Azure.StackExchangeRedis.IAzureCacheTokenEvents.ConnectionReauthenticated -> System.EventHandler<string!>?


### PR DESCRIPTION
Improve support for AAD tenants where token lifetimes that are configure for intervals other than 24 hours. 
- Change the token refresh margin from a hardcoded 4h to user-configurable lambda on `AzureCacheOptions`
- Default refresh margin to 75% of token lifetime. For example a token with a 24h lifetime will be eligible for refresh after 18h