### PR TITLE
Eliminate the need to specify a principalId/objectId/userName

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,24 @@ var configurationOptions = ConfigurationOptions.Parse($"{cacheHostName}:6380");
 
 ```csharp
 // DefaultAzureCredential
-await configurationOptions.ConfigureForAzureWithTokenCredentialAsync(userName, new DefaultAzureCredential());
+await configurationOptions.ConfigureForAzureWithTokenCredentialAsync(new DefaultAzureCredential());
 
 // User-assigned managed identity
-await configurationOptions.ConfigureForAzureWithUserAssignedManagedIdentityAsync(managedIdentityClientId, principalId);
+await configurationOptions.ConfigureForAzureWithUserAssignedManagedIdentityAsync(managedIdentityClientId);
 
 // System-assigned managed identity
-await configurationOptions.ConfigureForAzureWithSystemAssignedManagedIdentityAsync(principalId);
+await configurationOptions.ConfigureForAzureWithSystemAssignedManagedIdentityAsync();
 
 // Service principal secret
-await configurationOptions.ConfigureForAzureWithServicePrincipalAsync(clientId, principalId, tenantId, secret);
+await configurationOptions.ConfigureForAzureWithServicePrincipalAsync(clientId, tenantId, secret);
 
 // Service principal certificate
-await configurationOptions.ConfigureForAzureWithServicePrincipalAsync(clientId, principalId, tenantId, certificate);
+await configurationOptions.ConfigureForAzureWithServicePrincipalAsync(clientId, tenantId, certificate);
 
 // Service principal certificate with Subject Name + Issuer (SNI) authentication (Microsoft internal use only)
 await configurationOptions.ConfigureForAzureAsync(new AzureCacheOptions
 {
     ClientId = clientId,
-    PrincipalId = principalId,
     ServicePrincipalTenantId = tenantId,
     ServicePrincipalCertificate = certificate,
     SendX5C = true // Enables Subject Name + Issuer authentication

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Unreleased
+- Fix [#17](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/issues/17): Eliminate the need to specify a principalId/objectId/userName ([#48 by philon-msft](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/pull/48))
 - Add support for Subject Name + Issuer (SNI) certificate authentication ([#46 by philon-msft](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/pull/46))
 - Update dependency package versions ([#47 by philon-msft](https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/pull/47))
 

--- a/src/Microsoft.Azure.StackExchangeRedis.csproj
+++ b/src/Microsoft.Azure.StackExchangeRedis.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
   </ItemGroup>
 

--- a/src/PublicAPI.Shipped.txt
+++ b/src/PublicAPI.Shipped.txt
@@ -2,9 +2,10 @@
 StackExchange.Redis.AzureCacheForRedis
 static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzure.get -> System.Action<StackExchange.Redis.ConfigurationOptions!>!
 static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzureAsync(this StackExchange.Redis.ConfigurationOptions! configurationOptions, Microsoft.Azure.StackExchangeRedis.AzureCacheOptions! azureCacheOptions) -> System.Threading.Tasks.Task<StackExchange.Redis.ConfigurationOptions!>!
-static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzureWithServicePrincipalAsync(this StackExchange.Redis.ConfigurationOptions! configurationOptions, string! clientId, string! principalId, string! tenantId, string? secret = null, System.Security.Cryptography.X509Certificates.X509Certificate2? certificate = null, Microsoft.Identity.Client.AzureCloudInstance cloud = Microsoft.Identity.Client.AzureCloudInstance.AzurePublic, string? cloudUri = null) -> System.Threading.Tasks.Task<StackExchange.Redis.ConfigurationOptions!>!
-static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzureWithSystemAssignedManagedIdentityAsync(this StackExchange.Redis.ConfigurationOptions! configurationOptions, string! principalId) -> System.Threading.Tasks.Task<StackExchange.Redis.ConfigurationOptions!>!
-static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzureWithUserAssignedManagedIdentityAsync(this StackExchange.Redis.ConfigurationOptions! configurationOptions, string! clientId, string! principalId) -> System.Threading.Tasks.Task<StackExchange.Redis.ConfigurationOptions!>!
+static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzureWithTokenCredentialAsync(this StackExchange.Redis.ConfigurationOptions! configurationOptions, Azure.Core.TokenCredential! tokenCredential) -> System.Threading.Tasks.Task<StackExchange.Redis.ConfigurationOptions!>!
+static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzureWithUserAssignedManagedIdentityAsync(this StackExchange.Redis.ConfigurationOptions! configurationOptions, string! clientId) -> System.Threading.Tasks.Task<StackExchange.Redis.ConfigurationOptions!>!
+static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzureWithSystemAssignedManagedIdentityAsync(this StackExchange.Redis.ConfigurationOptions! configurationOptions) -> System.Threading.Tasks.Task<StackExchange.Redis.ConfigurationOptions!>!
+static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzureWithServicePrincipalAsync(this StackExchange.Redis.ConfigurationOptions! configurationOptions, string! clientId, string! tenantId, string? secret = null, System.Security.Cryptography.X509Certificates.X509Certificate2? certificate = null, Microsoft.Identity.Client.AzureCloudInstance cloud = Microsoft.Identity.Client.AzureCloudInstance.AzurePublic, string? cloudUri = null) -> System.Threading.Tasks.Task<StackExchange.Redis.ConfigurationOptions!>!
 Microsoft.Azure.StackExchangeRedis.TokenRefreshFailedEventArgs
 Microsoft.Azure.StackExchangeRedis.TokenRefreshFailedEventArgs.Exception.get -> System.Exception?
 Microsoft.Azure.StackExchangeRedis.TokenRefreshFailedEventArgs.Expiry.get -> System.DateTime?
@@ -13,7 +14,6 @@ Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.AzureCacheOptions() -> void
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.ClientId -> string?
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.Cloud -> Microsoft.Identity.Client.AzureCloudInstance
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.CloudUri -> string?
-Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.PrincipalId -> string?
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.ServicePrincipalCertificate -> System.Security.Cryptography.X509Certificates.X509Certificate2?
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.ServicePrincipalSecret -> string?
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.ServicePrincipalTenantId -> string?
@@ -35,4 +35,3 @@ Microsoft.Azure.StackExchangeRedis.TokenResult.Token.get -> string!
 Microsoft.Azure.StackExchangeRedis.TokenResult.Token.set -> void
 Microsoft.Azure.StackExchangeRedis.TokenResult.TokenResult(Azure.Core.AccessToken accessToken) -> void
 Microsoft.Azure.StackExchangeRedis.TokenResult.TokenResult(Microsoft.Identity.Client.AuthenticationResult! authenticationResult) -> void
-static StackExchange.Redis.AzureCacheForRedis.ConfigureForAzureWithTokenCredentialAsync(this StackExchange.Redis.ConfigurationOptions! configurationOptions, string! userName, Azure.Core.TokenCredential! tokenCredential) -> System.Threading.Tasks.Task<StackExchange.Redis.ConfigurationOptions!>!

--- a/src/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 ﻿#nullable enable
 Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.SendX5C -> bool
+Microsoft.Azure.StackExchangeRedis.AzureCacheOptions.GetUserName -> System.Func<string?, string!>!

--- a/tests/AzureCacheOptionsProviderWithTokenTests.cs
+++ b/tests/AzureCacheOptionsProviderWithTokenTests.cs
@@ -31,10 +31,7 @@ public class AzureCacheOptionsProviderWithTokenTests
         A.CallTo(() => fakeIdentityClient.GetTokenAsync()).Returns(tokenResult);
 
         var configurationOptions = new ConfigurationOptions();
-        var azureCacheOptions = new AzureCacheOptions()
-        {
-            PrincipalId = "userName"
-        };
+        var azureCacheOptions = new AzureCacheOptions();
         var optionsProviderWithToken = new AzureCacheOptionsProviderWithToken(azureCacheOptions);
         optionsProviderWithToken.IdentityClient = fakeIdentityClient; // Override the IIdentityClient created during instantiation of AzureCacheOptionsProviderWithToken 
 
@@ -65,7 +62,6 @@ public class AzureCacheOptionsProviderWithTokenTests
         var configurationOptions = new ConfigurationOptions();
         var azureCacheOptions = new AzureCacheOptions()
         {
-            PrincipalId = "userName",
             TokenCredential = tokenCredential
         };
         var optionsProviderWithToken = new AzureCacheOptionsProviderWithToken(azureCacheOptions);


### PR DESCRIPTION
Fix for #17 