### PR TITLE
Target net8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,16 +3,16 @@
     <!-- Packages we depend on for Microsoft.Azure.StackExchangeRedis, upgrades can create binding redirect pain! -->
     <PackageVersion Include="StackExchange.Redis" Version="2.8.24" />
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.67.2" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.68.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.5.0" />
     <!-- Packages only used in the solution, upgrade at will -->
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.7.2" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.7.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.8.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.8.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.427",
+    "version": "8.0.406",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/sample/Microsoft.Azure.StackExchangeRedis.Sample.csproj
+++ b/sample/Microsoft.Azure.StackExchangeRedis.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/src/Microsoft.Azure.StackExchangeRedis.csproj
+++ b/src/Microsoft.Azure.StackExchangeRedis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
     <Description>Extension package for StackExchange.Redis to be used with the Azure Cache for Redis service</Description>
     <AssemblyName>Microsoft.Azure.StackExchangeRedis</AssemblyName>
     <AssemblyTitle>Microsoft.Azure.StackExchangeRedis</AssemblyTitle>

--- a/src/Microsoft.Azure.StackExchangeRedis.csproj
+++ b/src/Microsoft.Azure.StackExchangeRedis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>Extension package for StackExchange.Redis to be used with the Azure Cache for Redis service</Description>
     <AssemblyName>Microsoft.Azure.StackExchangeRedis</AssemblyName>
     <AssemblyTitle>Microsoft.Azure.StackExchangeRedis</AssemblyTitle>

--- a/tests/Microsoft.Azure.StackExchangeRedis.Tests.csproj
+++ b/tests/Microsoft.Azure.StackExchangeRedis.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
This pull request includes several updates to package versions and target frameworks across multiple project files to ensure compatibility with .NET 8.0. The most important changes include updating the target framework versions in various project files and updating package versions in the `Directory.Packages.props` file.

Framework updates:

* [`global.json`](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL3-R3): Updated the .NET SDK version from 6.0.427 to 8.0.406.
* [`sample/Microsoft.Azure.StackExchangeRedis.Sample.csproj`](diffhunk://#diff-2d0e703b2f70f83f3000382c92de176a90c2ede24acc96f1db5e055a264910a9L4-R4): Changed the target framework from `net6.0` to `net8.0`.
* [`src/Microsoft.Azure.StackExchangeRedis.csproj`](diffhunk://#diff-012eeb67199cb503404c423e1627dc36f522028baef35f6a399d6c91cfce5708L4-R4): Updated the target frameworks from `netstandard2.0;net6.0` to `netstandard2.0;net8.0`.
* [`tests/Microsoft.Azure.StackExchangeRedis.Tests.csproj`](diffhunk://#diff-d30f39c2e2cf9f15abd96209b963c10bc852748883a8b63820ac90372a186ccbL4-R4): Changed the target frameworks from `net472;net6.0` to `net472;net8.0`.

Package version updates:

* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L6-R15): Updated multiple package versions, including `Microsoft.Identity.Client`, `Microsoft.IdentityModel.JsonWebTokens`, `Microsoft.NET.Test.Sdk`, and `MSTest` packages.